### PR TITLE
Add datetime-fortran to the registry

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1,0 +1,3 @@
+[datetime]
+"1.7.0" = {git="htttps://github.com/wavebitscientific/datetime-fortran", tag="v1.7.0"}
+"latest" = {git="htttps://github.com/wavebitscientific/datetime-fortran"}

--- a/registry.toml
+++ b/registry.toml
@@ -1,3 +1,3 @@
 [datetime]
-"1.7.0" = {git="htttps://github.com/wavebitscientific/datetime-fortran", tag="v1.7.0"}
-"latest" = {git="htttps://github.com/wavebitscientific/datetime-fortran"}
+"1.7.0" = {git="https://github.com/wavebitscientific/datetime-fortran", tag="v1.7.0"}
+"latest" = {git="https://github.com/wavebitscientific/datetime-fortran"}


### PR DESCRIPTION
I started registry.toml and added datetime-fortran to it. 

Note that for latest, I omitted the "branch" field because without it we can default to master, just like Cargo does.

Does this file look good?