### PR TITLE
add packages by @everythingfunctional

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -2,6 +2,12 @@
 "1.7.0" = {git="https://github.com/wavebitscientific/datetime-fortran", tag="v1.7.0"}
 "latest" = {git="https://github.com/wavebitscientific/datetime-fortran"}
 
+[iso_varying_string]
+"latest" = {git="https://gitlab.com/everythingfunctional/iso_varying_string"}
+
+[jsonff]
+"latest" = {git="https://gitlab.com/everythingfunctional/jsonff"}
+
 [M_calculator]
 "latest" = {git="https://github.com/urbanjost/M_calculator"}
 
@@ -31,3 +37,15 @@
 
 [M_time]
 "latest" = {git="https://github.com/urbanjost/M_time"}
+
+[quaff]
+"latest" = {git="https://gitlab.com/everythingfunctional/quaff"}
+
+[sqliteff]
+"latest" = {git="https://gitlab.com/everythingfunctional/sqliteff"}
+
+[strff]
+"latest" = {git="https://gitlab.com/everythingfunctional/strff"}
+
+[vegetables]
+"latest" = {git="https://gitlab.com/everythingfunctional/vegetables"}


### PR DESCRIPTION
Submitting packages by @everythingfunctional: iso_varying_string, jsonff, quaff, sqliteff, strff, vegetables.

@everythingfunctional please review, add specific versions if any (I only included latest/master), add any package I missed, or remove any that you don't think should be there.

Others, please review. IMO they pass all criteria from [here](https://github.com/fortran-lang/fortran-lang.org/blob/master/PACKAGES.md).