### PR TITLE
Update manifest constraints for registry

### DIFF
--- a/fpm_validate.py
+++ b/fpm_validate.py
@@ -42,7 +42,7 @@ def check_fpm_toml(contents):
                      "dev-dependencies"]
 
     # Optionally present, not copied to json
-    other_keys = ["test", "library"]
+    other_keys = ["test", "library", "build", "extra"]
 
     # Check for required keys
     for key in required_keys:


### PR DESCRIPTION
- add build (https://github.com/fortran-lang/fpm/issues/191) and extra (https://github.com/fortran-lang/fpm/pull/232) section to allowed keys in package manifest