### PR TITLE
Add packages to fpm registry

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -62,15 +62,12 @@
 
 [mctc-gcp]
 latest.git = "https://github.com/grimme-lab/gcp.git"
-latest.tag = "cd69ef6"  # Debug
 
 [mctc-lib]
 latest.git = "https://github.com/grimme-lab/mctc-lib.git"
-latest.tag = "61cdea0"  # Debug
 
 [mstore]
 latest.git = "https://github.com/grimme-lab/mstore.git"
-latest.tag = "6896b3b"  # Debug
 
 [pointsets]
 "latest" = {git="https://github.com/arjenmarkus/pointsets"}

--- a/registry.toml
+++ b/registry.toml
@@ -60,17 +60,32 @@
 [M_time]
 "latest" = {git="https://github.com/urbanjost/M_time"}
 
+[mctc-gcp]
+latest.git = "https://github.com/grimme-lab/gcp.git"
+
+[mctc-lib]
+latest.git = "https://github.com/grimme-lab/mctc-lib.git"
+
+[mstore]
+latest.git = "https://github.com/grimme-lab/mstore.git"
+
 [pointsets]
 "latest" = {git="https://github.com/arjenmarkus/pointsets"}
 
 [quaff]
 "latest" = {git="https://gitlab.com/everythingfunctional/quaff"}
 
+[s-dftd3]
+latest.git = "https://github.com/awvwgk/simple-dftd3.git"
+
 [sqliteff]
 "latest" = {git="https://gitlab.com/everythingfunctional/sqliteff"}
 
 [strff]
 "latest" = {git="https://gitlab.com/everythingfunctional/strff"}
+
+[toml-f]
+latest.git = "https://github.com/toml-f/toml-f.git"
 
 [vegetables]
 "latest" = {git="https://gitlab.com/everythingfunctional/vegetables"}

--- a/registry.toml
+++ b/registry.toml
@@ -62,12 +62,15 @@
 
 [mctc-gcp]
 latest.git = "https://github.com/grimme-lab/gcp.git"
+latest.tag = "cd69ef6"  # Debug
 
 [mctc-lib]
 latest.git = "https://github.com/grimme-lab/mctc-lib.git"
+latest.tag = "61cdea0"  # Debug
 
 [mstore]
 latest.git = "https://github.com/grimme-lab/mstore.git"
+latest.tag = "6896b3b"  # Debug
 
 [pointsets]
 "latest" = {git="https://github.com/arjenmarkus/pointsets"}


### PR DESCRIPTION
Adds a number of packages I've ported to fpm over the last months, mostly computational chemistry related.

#### IO
- [`toml-f`](https://github.com/toml-f): TOML parser implementation (fpm, meson, CMake)

#### Scientific
- [`mctc-lib`](https://grimme-lab.github.io/mctc-lib): Modular tool chain library for computational chemistry (fpm, meson, CMake)
- [`mstore`](https://github.com/grimme-lab/mstore): Molecular structure store for computational chemistry (fpm, meson)
- [`mctc-gcp`](https://github.com/grimme-lab/gcp): Geometrical counter-poise correction (fpm, meson)
- [`s-dftd3`](https://awvwgk.github.io/simple-dftd3): DFT-D3 dispersion correction (fpm, meson)