### PR TITLE
h5fortran

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -27,6 +27,11 @@ latest.git = "https://github.com/fortran-lang/fpm"
 [functional]
 "latest" = { git="https://github.com/wavebitscientific/functional-fortran" }
 
+[h5fortran]
+"4.6.3" = {git="https://github.com/geospace-code/h5fortran", tag="v4.6.3"}
+"latest" = {git="https://github.com/geospace-code/h5fortran"}
+
+
 [iso_varying_string]
 "latest" = {git="https://gitlab.com/everythingfunctional/iso_varying_string"}
 


### PR DESCRIPTION
It appears that fpm 0.2 supports submodule, so h5fortran should work. However I'm not sure how to link HDF5. Upon `fpm build` I get

> Unable to find source for module dependency: "h5lt" used by ".\src\attributes.f90"

`h5lt` is a module within HDF5 Fortran package. So maybe my [fpm.toml](https://github.com/geospace-code/h5fortran/blob/main/fpm.toml) needs improvement