### PR TITLE
add `fftpack` package

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -5,6 +5,9 @@
 [dftd4]
 latest.git = "https://github.com/dftd4/dftd4"
 
+[fftpack]
+"latest" = {git="https://github.com/keurfonluu/FFTPack"}
+
 [fhash]
 "0.1.0" = {git="https://github.com/LKedward/fhash", tag="v0.1.0"}
 "latest" = {git="https://github.com/LKedward/fhash"}


### PR DESCRIPTION
FFTPack aims to provide an easily usable package of functions using FFTPack library (Fortran 77).

This repo contains two libraries:
1. FFTpack library
   Contains FFT functions, useful functions like: `fft`, `ifft`, `fftshift`, and etc.
2. Forlab library
   Forlab is a Fortran module that provides a lot of functions for scientific computing mostly inspired by Matlab and Python's package NumPy.
   Useful functions like: `disp`, `ones`, `eye`, and etc.

Thank you, [keurfonluu](https://github.com/keurfonluu)!!😘👍