### PR TITLE
add `forlab` package

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -13,6 +13,10 @@ latest.git = "https://github.com/dftd4/dftd4"
 "1.2.2" = {git="https://github.com/jacobwilliams/finterp", tag="1.2.2"}
 "latest" = {git="https://github.com/jacobwilliams/finterp"}
 
+[forlab]
+"1.0.1" = { git="https://github.com/zoziha/forlab", tag="v1.0.1" }
+"latest" = { git="https://github.com/zoziha/forlab" }
+
 [iso_varying_string]
 "latest" = {git="https://gitlab.com/everythingfunctional/iso_varying_string"}
 


### PR DESCRIPTION
Add `forlab` package, `Forlab` is a Fortran module that provides a lot of functions for scientific computing mostly inspired by Matlab and Python's module NumPy. `Forlab` is developed by [Keurfon Luu](https://github.com/keurfonluu?tab=repositories) before.
(issue see #41 )
