### PR TITLE
Add nlopt-f to registry

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -92,6 +92,9 @@ latest.git = "https://github.com/grimme-lab/multicharge.git"
 [neural-fortran]
 "latest" = { git="https://github.com/modern-fortran/neural-fortran" }
 
+[nlopt-f]
+latest.git = "https://github.com/grimme-lab/nlopt-f"
+
 [pointsets]
 "latest" = {git="https://github.com/arjenmarkus/pointsets"}
 


### PR DESCRIPTION
- Fortran bindings for NLopt library
- source at [grimme-lab/nlopt-f](https://github.com/grimme-lab/nlopt-f)
- supports fpm, meson and cmake