### PR TITLE
Add tblite project to registry

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -107,6 +107,9 @@ latest.git = "https://github.com/awvwgk/simple-dftd3.git"
 [strff]
 "latest" = {git="https://gitlab.com/everythingfunctional/strff"}
 
+[tblite]
+latest.git = "https://github.com/awvwgk/tblite"
+
 [test-drive]
 latest.git = "https://github.com/awvwgk/test-drive"
 


### PR DESCRIPTION
This is my largest fpm project so far with more than 500 source files in 6 fpm projects. Still a bit experimental, but is already integrated in projects like [DFTB+](https://github.com/dftbplus/dftbplus) and [QCxMS](https://github.com/qcxms/qcxms). I can say that this project would not have been possible without fpm.

- source at [awvwgk/tblite](https://github.com/awvwgk/tblite)
- supports fpm, meson and CMake as build system
- GCC 8 and newer and Intel 18 and newer are supported
- documentation at https://tblite.readthedocs.io
- implements [10.1021/acs.jctc.8b01176](https://pubs.acs.org/doi/10.1021/acs.jctc.8b01176) (open access)