### PR TITLE
Add `fortran-lang/fftpack` package

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -5,6 +5,10 @@
 [dftd4]
 latest.git = "https://github.com/dftd4/dftd4"
 
+[fftpack]
+"4.0.0" = {git="https://github.com/fortran-lang/fftpack", tag="v4.0.0"}
+"latest" = {git="https://github.com/fortran-lang/fftpack"}
+
 [fhash]
 "0.1.0" = {git="https://github.com/LKedward/fhash", tag="v0.1.0"}
 "latest" = {git="https://github.com/LKedward/fhash"}


### PR DESCRIPTION
#### Description

`fftpack` is now developed under the `fortran-lang` organization. Yesterday @awvwgk  released version `4.0.0` of `fortran-lang/fftpack` (mainly added fpm support). 

So I now submit `fortran-lang/fftpack` to `fpm-registry` and close #40 .

#### Content irrelevant to this PR

Originally, I wanted to submit `fftpack` and `stdlib-fpm` together, but found that it seems that `fpm-registry` does **not support `branch` analysis** like this:

```toml
[stdlib]
"latest" = { git = "https://github.com/fortran-lang/stdlib", branch = "stdlib-fpm" }
```