### PR TITLE
Add `fortran-lang/stdlib` package.

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -111,6 +111,9 @@ latest.git = "https://github.com/awvwgk/simple-dftd3.git"
 [sqliteff]
 "latest" = {git="https://gitlab.com/everythingfunctional/sqliteff"}
 
+[stdlib]
+"latest" = {git="https://github.com/fortran-lang/stdlib", branch="stdlib-fpm"}
+
 [strff]
 "latest" = {git="https://gitlab.com/everythingfunctional/strff"}
 

--- a/registry.toml
+++ b/registry.toml
@@ -112,7 +112,7 @@ latest.git = "https://github.com/awvwgk/simple-dftd3.git"
 "latest" = {git="https://gitlab.com/everythingfunctional/sqliteff"}
 
 [stdlib]
-"latest" = {git="https://github.com/fortran-lang/stdlib", branch="stdlib-fpm"}
+"latest" = {git="https://github.com/fortran-lang/stdlib", tag="stdlib-fpm"}
 
 [strff]
 "latest" = {git="https://gitlab.com/everythingfunctional/strff"}


### PR DESCRIPTION
#### Description

Now `stdlib` can be used as a fpm dependency for your fpm project.
(see [build with fpm](https://github.com/fortran-lang/stdlib#build-with-fortran-langfpm))

So I now submit `fortran-lang/stdlib` to `fpm-registry`. (close #54 )