### PR TITLE
Adding Fortran Error Handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Your new registry submittal should first meet the
 required of any package listed at the
 [packages listing](https://fortran-lang.org/packages).
 
-Please submit a [pull request](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github)
+Please submit a [pull request](https://app.egghead.io/playlists/how-to-contribute-to-an-open-source-project-on-github)
 against this repository, adding the new package into the file
 [registry.toml](./registry.toml)
 in alphabetical order. It is recommended that you explicitly list each version using the 

--- a/registry.toml
+++ b/registry.toml
@@ -21,6 +21,10 @@ latest.git = "https://github.com/dftd4/dftd4"
 "1.0.1" = { git="https://github.com/zoziha/forlab", tag="v1.0.1" }
 "latest" = { git="https://github.com/zoziha/forlab" }
 
+[fortran-error-handler]
+"1.0.3" = { git="https://github.com/samharrison7/fortran-error-handler", tag="1.0.3" }
+"latest" = { git="https://github.com/samharrison7/fortran-error-handler" }
+
 [fpm]
 latest.git = "https://github.com/fortran-lang/fpm"
 

--- a/registry.toml
+++ b/registry.toml
@@ -22,7 +22,7 @@ latest.git = "https://github.com/dftd4/dftd4"
 "latest" = { git="https://github.com/zoziha/forlab" }
 
 [fortran-error-handler]
-"1.0.3" = { git="https://github.com/samharrison7/fortran-error-handler", tag="1.0.3" }
+"1.0.4" = { git="https://github.com/samharrison7/fortran-error-handler", tag="1.0.4" }
 "latest" = { git="https://github.com/samharrison7/fortran-error-handler" }
 
 [fpm]


### PR DESCRIPTION
I've just fpm-ified my Fortran error handler and so thought it would be a good time to add it here. I've also created a separate PR over at fortran-lang.org: https://github.com/fortran-lang/fortran-lang.org/pull/356 (is that the way to do it, or should I have just created one PR?)

I also spotted a broken link in the README so have fixed that here.