### PR TITLE
Add `version-f` to the registry

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -128,3 +128,7 @@ latest.git = "https://github.com/toml-f/toml-f.git"
 
 [vegetables]
 "latest" = {git="https://gitlab.com/everythingfunctional/vegetables"}
+
+[version-f]
+"0.1.0" = {git="https://github.com/minhqdao/version-f", tag="v0.1.0"}
+"latest" = {git="https://github.com/minhqdao/version-f"}


### PR DESCRIPTION
Adding [version-f](https://github.com/minhqdao/version-f) to the registry.

It's a complete implementation of [Semantic Versioning 2.0](https://semver.org) in Fortran.