### PR TITLE
feat: register `fortran-utils`

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -21,6 +21,9 @@ latest.git = "https://github.com/dftd4/dftd4"
 "1.0.1" = { git="https://github.com/zoziha/forlab", tag="v1.0.1" }
 "latest" = { git="https://github.com/zoziha/forlab" }
 
+[fortran-utils]
+latest.git = "https://github.com/certik/fortran-utils"
+
 [fpm]
 latest.git = "https://github.com/fortran-lang/fpm"
 


### PR DESCRIPTION
Registers: https://github.com/certik/fortran-utils/, as requested in https://github.com/fortran-lang/fpm/issues/17