### PR TITLE
Add capnp (capnp-fortran) 0.1.0

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1,3 +1,7 @@
+[capnp]
+"0.1.0" = {git="https://github.com/HaoZeke/capnp-fortran", tag="v0.1.0"}
+"latest" = {git="https://github.com/HaoZeke/capnp-fortran"}
+
 [datetime]
 "1.7.0" = {git="https://github.com/wavebitscientific/datetime-fortran", tag="v1.7.0"}
 "latest" = {git="https://github.com/wavebitscientific/datetime-fortran"}


### PR DESCRIPTION
## Summary

Register **capnp** from https://github.com/HaoZeke/capnp-fortran at tag `v0.1.0`.

Native modern-Fortran (F2018) Cap'n Proto: wire runtime, `capnpc-fortran` schema compiler plugin, optional C ABI, two-party RPC. MIT license.

## registry.toml

```toml
[capnp]
"0.1.0" = {git="https://github.com/HaoZeke/capnp-fortran", tag="v0.1.0"}
"latest" = {git="https://github.com/HaoZeke/capnp-fortran"}
```

## Links

- Release: https://github.com/HaoZeke/capnp-fortran/releases/tag/v0.1.0