### PR TITLE
Add GaussJacobiQuad package

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -27,6 +27,10 @@ latest.git = "https://github.com/fortran-lang/fpm"
 [functional]
 "latest" = { git="https://github.com/wavebitscientific/functional-fortran" }
 
+[GaussJacobiQuad]
+"0.1.0" = {git="https://github.com/HaoZeke/GaussJacobiQuad", tag="v0.1.0"}
+"latest" = {git="https://github.com/HaoZeke/GaussJacobiQuad"}
+
 [iso_varying_string]
 "latest" = {git="https://gitlab.com/everythingfunctional/iso_varying_string"}
 


### PR DESCRIPTION
## Summary

Register [GaussJacobiQuad](https://github.com/HaoZeke/GaussJacobiQuad) in the fpm package registry.

- **Purpose:** MIT-licensed modern Fortran implementation of Gauss–Jacobi quadrature (nodes and weights on `[-1, 1]`).
- **fpm name:** `GaussJacobiQuad` (matches `fpm.toml`)
- **Versions:** `0.1.0` tagged as `v0.1.0`, plus `latest` on the default branch
- **Criteria check:** Fortran numerical library, mature primary API, open source (MIT), README with build/usage, fpm + meson support, tests present; GitHub stars meet the package index maturity bar (5)

Validated locally with `python load_registry.py`.

## Test plan

- [x] `python load_registry.py` succeeds with the new entry
- [ ] CI on this PR validates `registry.toml`
- [ ] After merge, package appears at https://fortran-lang.org/packages/fpm